### PR TITLE
Use application data directory if flag saveFileInExtStorage is false

### DIFF
--- a/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
+++ b/android/src/main/java/com/rssignaturecapture/RSSignatureCaptureMainView.java
@@ -140,7 +140,10 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
    */
   final void saveImage() {
 
-    String root = Environment.getExternalStorageDirectory().toString();
+    String root = mActivity.getExternalFilesDir(Environment.DIRECTORY_PICTURES).toString();
+    if (saveFileInExtStorage) {
+      root = Environment.getExternalStorageDirectory().toString();
+    }
 
     // the directory where the signature will be saved
     File myDir = new File(root + "/saved_signature");
@@ -165,12 +168,10 @@ public class RSSignatureCaptureMainView extends LinearLayout implements OnClickL
 
       Log.d("React Signature", "Save file-======:" + saveFileInExtStorage);
       // save the signature
-      if (saveFileInExtStorage) {
-        FileOutputStream out = new FileOutputStream(file);
-        this.signatureView.getSignature().compress(Bitmap.CompressFormat.PNG, 90, out);
-        out.flush();
-        out.close();
-      }
+      FileOutputStream out = new FileOutputStream(file);
+      this.signatureView.getSignature().compress(Bitmap.CompressFormat.PNG, 90, out);
+      out.flush();
+      out.close()
 
 
       ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
Ref: https://github.com/RepairShopr/react-native-signature-capture/pull/98